### PR TITLE
LEAF_IOS-313

### DIFF
--- a/Classes/AXStretchableHeaderTabViewController.h
+++ b/Classes/AXStretchableHeaderTabViewController.h
@@ -23,6 +23,7 @@
 @property (readonly, nonatomic) AXTabBar *tabBar;
 @property (weak, nonatomic) IBOutlet UIScrollView *containerView;
 @property (nonatomic) BOOL shouldBounceHeaderView;
+@property (nonatomic) BOOL shouldAllowSwipingToChangeTabs;
 
 // Layout
 - (void)layoutHeaderViewAndTabBar;

--- a/Classes/AXStretchableHeaderTabViewController.m
+++ b/Classes/AXStretchableHeaderTabViewController.m
@@ -208,7 +208,8 @@ static NSString * const AXStretchableHeaderTabViewControllerSelectedIndexKey = @
       [viewController.view setFrame:UIEdgeInsetsInsetRect(newFrame, contentInsets)];
     }
   }];
-  [_containerView setContentSize:(CGSize){size.width * _viewControllers.count, 0.0}];
+  NSUInteger controllersToShow = (_shouldAllowSwipingToChangeTabs) ? _viewControllers.count : 1;
+  [_containerView setContentSize:(CGSize){size.width * controllersToShow, 0.0}];
 }
 
 - (void)layoutSubViewControllerToSelectedViewController
@@ -263,6 +264,12 @@ static NSString * const AXStretchableHeaderTabViewControllerSelectedIndexKey = @
     }
   }];
 }
+
+- (void)setShouldAllowSwipingToChangeTabs:(BOOL)shouldAllowSwipingToChangeTabs {
+    _shouldAllowSwipingToChangeTabs = shouldAllowSwipingToChangeTabs;
+    [self layoutViewControllers];
+}
+
 
 #pragma mark - KVO
 


### PR DESCRIPTION
This PR contains a fix to add a boolean that allows us to restrict swiping between view controllers, useful for when we're hiding the tabs (i.e.: LEAFSearchViewController). Please take a look, @nickelsberry. Thanks!!
